### PR TITLE
Allow config of relative path for orleans dashboard

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -36,7 +36,7 @@ services:
    image:
      registry_type: DOCR
      repository: web-scheduler-server
-     tag: 0.1.1-alpha.0.12
+     tag: 0.1.1
    instance_count: 3
    instance_size_slug: professional-xs
    internal_ports:
@@ -44,7 +44,7 @@ services:
    - 30000
    - 80
    routes:
-     - path: /
+     - path: /OrleansDashboard
  - name: web-scheduler-api
    envs:
    - key: Redis__ConnectionString
@@ -69,7 +69,7 @@ services:
    image:
      registry_type: DOCR
      repository: web-scheduler-api
-     tag: 0.1.1-alpha.0.7
+     tag: 0.1.1
    instance_count: 2
    instance_size_slug: professional-xs
    routes:
@@ -77,3 +77,12 @@ services:
    health_check:
      http_path: /status
      port: 80
+static_sites:
+- environment_slug: html
+  github:
+    branch: release
+    deploy_on_push: true
+    repo: web-scheduler/web-scheduler-frontend
+  name: web-scheduler-frontend
+  routes:
+  - path: /

--- a/Source/WebScheduler.Abstractions/Grains/Scheduler/IScheduledTaskGrain.cs
+++ b/Source/WebScheduler.Abstractions/Grains/Scheduler/IScheduledTaskGrain.cs
@@ -22,35 +22,3 @@ public interface IScheduledTaskGrain : IGrainWithStringKey
     /// <returns>The scheduled task metadata.</returns>
     ValueTask<ScheduledTaskMetadata?> GetAsync();
 }
-
-/// <summary>
-/// Model for Scheduled Task metadata
-/// </summary>
-public class ScheduledTaskMetadata
-{
-
-    /// <summary>
-    /// Created timestamp.
-    /// </summary>
-    public DateTimeOffset Created { get; set; }
-
-    /// <summary>
-    /// Last modified timestamp.
-    /// </summary>
-    public DateTimeOffset Modified { get; set; }
-
-    /// <summary>
-    /// The name of the scheduled task.
-    /// </summary>
-    public string Name { get; set; } = string.Empty;
-
-    /// <summary>
-    /// The description of the scheduled task.
-    /// </summary>
-    public string Description { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Specifies if the task is enabled.
-    /// </summary>
-    public bool IsEnabled { get; set; }
-}

--- a/Source/WebScheduler.Abstractions/Grains/Scheduler/ScheduledTaskMetadata.cs
+++ b/Source/WebScheduler.Abstractions/Grains/Scheduler/ScheduledTaskMetadata.cs
@@ -1,0 +1,33 @@
+﻿namespace WebScheduler.Abstractions.Grains.Scheduler;
+
+/// <summary>
+/// Model for Scheduled Task metadata
+/// </summary>
+public class ScheduledTaskMetadata
+{
+
+    /// <summary>
+    /// Created timestamp.
+    /// </summary>
+    public DateTimeOffset Created { get; set; }
+
+    /// <summary>
+    /// Last modified timestamp.
+    /// </summary>
+    public DateTimeOffset Modified { get; set; }
+
+    /// <summary>
+    /// The name of the scheduled task.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The description of the scheduled task.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Specifies if the task is enabled.
+    /// </summary>
+    public bool IsEnabled { get; set; }
+}

--- a/Source/WebScheduler.Server/Options/ApplicationOptions.cs
+++ b/Source/WebScheduler.Server/Options/ApplicationOptions.cs
@@ -12,4 +12,6 @@ public class ApplicationOptions
     public StorageOptions Storage { get; set; } = default!;
 
     public ClusterMembershipOptions ClusterMembership { get; set; } = default!;
+
+    public OrleansDashboard.DashboardOptions OrleansDashboard { get; set; } = default!;
 }

--- a/Source/WebScheduler.Server/Program.cs
+++ b/Source/WebScheduler.Server/Program.cs
@@ -132,7 +132,7 @@ public class Program
             .UseIf(
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
                 x => x.UsePerfCounterEnvironmentStatistics())
-            .UseDashboard();
+            .UseDashboard(options => options.BasePath = GetOrleansDashboardOptions(context.Configuration).BasePath);
 
     private static void ConfigureWebHostBuilder(IWebHostBuilder webHostBuilder) =>
         webHostBuilder
@@ -185,4 +185,7 @@ public class Program
 
     private static StorageOptions GetStorageOptions(IConfiguration configuration) =>
         configuration.GetSection(nameof(ApplicationOptions.Storage)).Get<StorageOptions>();
+
+    private static OrleansDashboard.DashboardOptions GetOrleansDashboardOptions(IConfiguration configuration) =>
+        configuration.GetSection(nameof(ApplicationOptions.OrleansDashboard)).Get<OrleansDashboard.DashboardOptions>();
 }

--- a/Source/WebScheduler.Server/Properties/launchSettings.json
+++ b/Source/WebScheduler.Server/Properties/launchSettings.json
@@ -10,7 +10,7 @@
     "Development": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:8080",
+      "launchUrl": "http://localhost:8080/OrleansDashboard",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
@@ -21,7 +21,7 @@
     "Production": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:8080",
+      "launchUrl": "http://localhost:8080/OrleansDashboard",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Production"
@@ -50,7 +50,7 @@
     "WSL": {
       "commandName": "WSL2",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:8080/",
+      "launchUrl": "http://localhost:8080/OrleansDashboard",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       },

--- a/Source/WebScheduler.Server/appsettings.json
+++ b/Source/WebScheduler.Server/appsettings.json
@@ -41,6 +41,9 @@
   },
   "Storage": {
     "Invariant": "MySql.Data.MySqlClient",
-    "ConnectionString": "Server=DB_HOST_NAME;Port=25060;Database=defaultdb;Userid=XXX;Password=XXX;SslMode=Required;",
+    "ConnectionString": "Server=DB_HOST_NAME;Port=25060;Database=defaultdb;Userid=XXX;Password=XXX;SslMode=Required;"
+  },
+  "OrleansDashboard": {
+    "BasePath":  "/OrleansDashboard"
   }
 }


### PR DESCRIPTION
Allow config of relative path for orleans dashboard, default to `/OrleansDashboard`

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/web-scheduler/web-scheduler/blob/main/.github/CONTRIBUTING.md
-->
