### PR TITLE
Scheduled Task Exceptions were using `GetPrimaryKeyGuid()` instead of `GetPrimaryKeyString()`

### DIFF
--- a/Source/WebScheduler.Abstractions/Grains/Scheduler/ScheduledTaskAlreadyExistsException.cs
+++ b/Source/WebScheduler.Abstractions/Grains/Scheduler/ScheduledTaskAlreadyExistsException.cs
@@ -10,7 +10,7 @@ public class ScheduledTaskAlreadyExistsException : Exception
     /// <summary>
     /// The Id.
     /// </summary>
-    public Guid Id { get; init; }
+    public string Id { get; init; } = string.Empty;
 
     /// <inheritdoc/>
     protected ScheduledTaskAlreadyExistsException()
@@ -21,10 +21,10 @@ public class ScheduledTaskAlreadyExistsException : Exception
     /// By Id
     /// </summary>
     /// <param name="id">the Id</param>
-    public ScheduledTaskAlreadyExistsException(Guid id) : base($"Scheduled task with id {id} already exists.") => this.Id = id;
+    public ScheduledTaskAlreadyExistsException(string id) : base($"Scheduled task with id {id} already exists.") => this.Id = id;
 
     /// <inheritdoc/>
-    public ScheduledTaskAlreadyExistsException(Guid id, Exception? innerException) : base($"Scheduled task with id {id} already exists.", innerException) => this.Id = id;
+    public ScheduledTaskAlreadyExistsException(string id, Exception? innerException) : base($"Scheduled task with id {id} already exists.", innerException) => this.Id = id;
 
     /// <inheritdoc/>
     protected ScheduledTaskAlreadyExistsException(SerializationInfo info, StreamingContext context) : base(info, context)

--- a/Source/WebScheduler.Abstractions/Grains/Scheduler/ScheduledTaskNotFoundException.cs
+++ b/Source/WebScheduler.Abstractions/Grains/Scheduler/ScheduledTaskNotFoundException.cs
@@ -10,7 +10,7 @@ public class ScheduledTaskNotFoundException : Exception
     /// <summary>
     /// The Id.
     /// </summary>
-    public Guid Id { get; init; }
+    public string Id { get; init; } = string.Empty;
 
     /// <inheritdoc/>
     protected ScheduledTaskNotFoundException()
@@ -21,10 +21,10 @@ public class ScheduledTaskNotFoundException : Exception
     /// By Id
     /// </summary>
     /// <param name="id">the Id</param>
-    public ScheduledTaskNotFoundException(Guid id) : base($"Scheduled task with id {id} already exists.") => this.Id = id;
+    public ScheduledTaskNotFoundException(string id) : base($"Scheduled task with id {id} already exists.") => this.Id = id;
 
     /// <inheritdoc/>
-    public ScheduledTaskNotFoundException(Guid id, Exception? innerException) : base($"Scheduled task with id {id} already exists.", innerException) => this.Id = id;
+    public ScheduledTaskNotFoundException(string id, Exception? innerException) : base($"Scheduled task with id {id} already exists.", innerException) => this.Id = id;
 
     /// <inheritdoc/>
     protected ScheduledTaskNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)

--- a/Source/WebScheduler.Grains/Scheduler/ScheduledTaskGrain.cs
+++ b/Source/WebScheduler.Grains/Scheduler/ScheduledTaskGrain.cs
@@ -40,7 +40,7 @@ public class ScheduledTaskGrain : Grain, IScheduledTaskGrain, IRemindable, ITena
         if (this.scheduledTaskMetadata.RecordExists)
         {
             this.logger.ScheduledTaskAlreadyExists(this.GetPrimaryKeyString());
-            throw new ScheduledTaskAlreadyExistsException(this.GetPrimaryKey());
+            throw new ScheduledTaskAlreadyExistsException(this.GetPrimaryKeyString());
         }
         this.scheduledTaskMetadata.State = scheduledTaskMetadata;
 
@@ -65,7 +65,7 @@ public class ScheduledTaskGrain : Grain, IScheduledTaskGrain, IRemindable, ITena
         if (!this.scheduledTaskMetadata.RecordExists)
         {
             this.logger.ScheduledTaskAlreadyExists(this.GetPrimaryKeyString());
-            throw new ScheduledTaskNotFoundException(this.GetPrimaryKey());
+            throw new ScheduledTaskNotFoundException(this.GetPrimaryKeyString());
         }
 
         this.scheduledTaskMetadata.State.CronExpression = scheduledTaskMetadata.CronExpression;
@@ -115,7 +115,7 @@ public class ScheduledTaskGrain : Grain, IScheduledTaskGrain, IRemindable, ITena
         if (!this.scheduledTaskMetadata.RecordExists)
         {
             this.logger.ScheduledTaskDoesNotExists(this.GetPrimaryKeyString());
-            throw new ScheduledTaskNotFoundException(this.GetPrimaryKey());
+            throw new ScheduledTaskNotFoundException(this.GetPrimaryKeyString());
         }
 
         return new ValueTask<ScheduledTaskMetadata>(this.scheduledTaskMetadata.State);
@@ -127,7 +127,7 @@ public class ScheduledTaskGrain : Grain, IScheduledTaskGrain, IRemindable, ITena
         if (!this.scheduledTaskMetadata.RecordExists)
         {
             this.logger.ScheduledTaskDoesNotExists(this.GetPrimaryKeyString());
-            throw new ScheduledTaskNotFoundException(this.GetPrimaryKey());
+            throw new ScheduledTaskNotFoundException(this.GetPrimaryKeyString());
         }
 
         this.scheduledTaskMetadata.State.IsDeleted = true;


### PR DESCRIPTION
Correct misuse of Guid Primary Key functionality in `ScheduledTaskGrain` and switch ScheduledTaskExceptions to strings instead of Guids.

Fixes #134 