### PR TITLE
Deploy new image name and enable migrations job

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -19,6 +19,38 @@ domains:
   type: PRIMARY
 features:
 - enable-kata-build
+jobs:
+- alerts:
+  - operator: GREATER_THAN
+    rule: CPU_UTILIZATION
+    value: 80
+    window: FIVE_MINUTES
+  - operator: GREATER_THAN
+    rule: MEM_UTILIZATION
+    value: 80
+    window: FIVE_MINUTES
+  - operator: GREATER_THAN
+    rule: RESTART_COUNT
+    value: 1
+    window: FIVE_MINUTES
+  envs:
+  - key: ASPNETCORE_ENVIRONMENT
+    scope: RUN_AND_BUILD_TIME
+    value: Production
+  - key: Kestrel__Endpoints__Http__Url
+    scope: RUN_TIME
+    value: http://*:80
+  - key: ConnectionStrings__Default
+    scope: RUN_TIME
+    value: Server=${web-scheduler-prod.HOSTNAME};Port=${web-scheduler-prod.PORT};Database=orleans;UserId=${web-scheduler-prod.USERNAME};Password=${web-scheduler-prod.PASSWORD};SslMode=Required;
+  image:
+    registry_type: DOCR
+    repository: webscheduler-datamigrations
+    tag: 0.1.33
+  instance_count: 1
+  instance_size_slug: professional-xs
+  kind: PRE_DEPLOY
+  name: web-scheduler-datamigrator-job
 name: web-scheduler
 region: nyc
 services:
@@ -57,8 +89,8 @@ services:
   http_port: 8080
   image:
     registry_type: DOCR
-    repository: web-scheduler-server
-    tag: 0.1.32
+    repository: webscheduler-server
+    tag: 0.1.33
   instance_count: 5
   instance_size_slug: professional-xl
   internal_ports:
@@ -130,33 +162,3 @@ static_sites:
   routes:
   - path: /
     preserve_path_prefix: true
-jobs:
-- name: web-scheduler-datamigrator-job
-  image:
-    registry_type: DOCR
-    repository: webscheduler-datamigrations
-    tag: 0.1.34
-  envs:
-  - key: ASPNETCORE_ENVIRONMENT
-    scope: RUN_AND_BUILD_TIME
-    value: Production
-  - key: Kestrel__Endpoints__Http__Url
-    scope: RUN_TIME
-    value: http://*:80
-  - key: ConnectionStrings__Default
-    scope: RUN_TIME
-    value: Server=${web-scheduler-prod.HOSTNAME};Port=${web-scheduler-prod.PORT};Database=orleans;UserId=${web-scheduler-prod.USERNAME};Password=${web-scheduler-prod.PASSWORD};SslMode=Required;
-  kind: POST_DEPLOY
-  alerts:
-    - operator: GREATER_THAN
-      rule: CPU_UTILIZATION
-      value: 80
-      window: FIVE_MINUTES
-    - operator: GREATER_THAN
-      rule: MEM_UTILIZATION
-      value: 80
-      window: FIVE_MINUTES
-    - operator: GREATER_THAN
-      rule: RESTART_COUNT
-      value: 1
-      window: FIVE_MINUTES

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -86,6 +86,7 @@ services:
   health_check:
     http_path: /status/self
     port: 80
+    initial_delay_seconds: 120
   http_port: 8080
   image:
     registry_type: DOCR
@@ -141,6 +142,7 @@ services:
     value: Server=${web-scheduler-prod.HOSTNAME};Port=${web-scheduler-prod.PORT};Database=DataProtection;UserId=${web-scheduler-prod.USERNAME};Password=${web-scheduler-prod.PASSWORD};SslMode=Required;
   health_check:
     http_path: /status
+    initial_delay_seconds: 120
   http_port: 80
   image:
     registry_type: DOCR

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -54,14 +54,13 @@ services:
   health_check:
     http_path: /status/self
     port: 80
-    initial_delay_seconds: 120
   http_port: 8080
   image:
     registry_type: DOCR
     repository: web-scheduler-server
-    tag: 0.1.25
+    tag: 0.1.32
   instance_count: 5
-  instance_size_slug: professional-xs
+  instance_size_slug: professional-xl
   internal_ports:
   - 11111
   - 30000
@@ -110,12 +109,11 @@ services:
     value: Server=${web-scheduler-prod.HOSTNAME};Port=${web-scheduler-prod.PORT};Database=DataProtection;UserId=${web-scheduler-prod.USERNAME};Password=${web-scheduler-prod.PASSWORD};SslMode=Required;
   health_check:
     http_path: /status
-    initial_delay_seconds: 120
   http_port: 80
   image:
     registry_type: DOCR
     repository: web-scheduler-api
-    tag: 0.1.33
+    tag: 0.1.43
   instance_count: 3
   instance_size_slug: professional-xs
   name: web-scheduler-api
@@ -132,3 +130,33 @@ static_sites:
   routes:
   - path: /
     preserve_path_prefix: true
+jobs:
+- name: web-scheduler-datamigrator-job
+  image:
+    registry_type: DOCR
+    repository: webscheduler-datamigrations
+    tag: 0.1.34
+  envs:
+  - key: ASPNETCORE_ENVIRONMENT
+    scope: RUN_AND_BUILD_TIME
+    value: Production
+  - key: Kestrel__Endpoints__Http__Url
+    scope: RUN_TIME
+    value: http://*:80
+  - key: ConnectionStrings__Default
+    scope: RUN_TIME
+    value: Server=${web-scheduler-prod.HOSTNAME};Port=${web-scheduler-prod.PORT};Database=orleans;UserId=${web-scheduler-prod.USERNAME};Password=${web-scheduler-prod.PASSWORD};SslMode=Required;
+  kind: POST_DEPLOY
+  alerts:
+    - operator: GREATER_THAN
+      rule: CPU_UTILIZATION
+      value: 80
+      window: FIVE_MINUTES
+    - operator: GREATER_THAN
+      rule: MEM_UTILIZATION
+      value: 80
+      window: FIVE_MINUTES
+    - operator: GREATER_THAN
+      rule: RESTART_COUNT
+      value: 1
+      window: FIVE_MINUTES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         run: mkdir -p ./migrator
       - name: Build Bundler ${{matrix.db}}:${{matrix.version}}
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: dotnet ef migrations bundle --self-contained -r linux-x64 --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator/efbundle
+        run: dotnet ef migrations bundle --self-contained --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator/efbundle
       - name: Execute Bundler ${{matrix.db}}:${{matrix.version}}
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./migrator/efbundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
       DOCKER_REPOSITORY_NAME: web-scheduler
     environment: #TODO: Switch this to PR URL
        name: "DOCR registry.digitalocean.com/web-scheduler"
-       url: https://registry.digitalocean.com/web-scheduler/web-scheduler-server
+       url: https://registry.digitalocean.com/web-scheduler
     permissions:
       packages: write
     runs-on: ${{matrix.os}}
@@ -264,6 +264,11 @@ jobs:
               {
                 "name": "web-scheduler-server",
                 "repository": "${{env.DOCKER_REGISTRY}}/${{env.DOCKER_REPOSITORY_NAME}}/webscheduler-server",
+                "tag": "${{ steps.read_file.outputs.contents }}"
+              },
+              {
+                "name": "web-scheduler-datamigrator-job",
+                "repository": "${{env.DOCKER_REGISTRY}}/${{env.DOCKER_REPOSITORY_NAME}}/webscheduler-datamigrations",
                 "tag": "${{ steps.read_file.outputs.contents }}"
               }]'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         run: mkdir -p ./migrator
       - name: Build Bundler ${{matrix.db}}:${{matrix.version}}
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: dotnet ef migrations bundle --self-contained -r linux-x64 --verbose --configuration Bundle --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator/efbundle
+        run: dotnet ef migrations bundle --self-contained -r linux-x64 --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator/efbundle
       - name: Execute Bundler ${{matrix.db}}:${{matrix.version}}
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./migrator/efbundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
       matrix:
         db: [mysql] # we require a MySQL Instance to build the efbundler
         version: ["8.0.27"]
-        os: [ubuntu-latest] # windows-latest, macOS-latest
+        os: [ubuntu-latest] # windows-latest, macOS-latest'
+        rid: [linux-x64, linux-musl-x64]
     steps:
       - name: Pull ${{matrix.db}}:${{matrix.version}} and setup Docker
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -79,19 +80,18 @@ jobs:
       - name: "Dotnet Cake Build"
         run: dotnet cake --target=Build
         shell: pwsh
-      - name: Make ./migrator directory
-        run: mkdir -p ./migrator
-      - name: Build Bundler ${{matrix.db}}:${{matrix.version}}
+      - name: Make ./migrator-${{matrix.rid}} directory
+        run: mkdir -p ./migrator-${{matrix.rid}}
+      - name: Build Bundler for ${{matrix.rid}} on ${{matrix.db}}:${{matrix.version}}
+        run: dotnet ef migrations bundle --self-contained -r ${{matrix.rid}} --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator-${{matrix.rid}}/efbundle
+      - name: Execute Bundler ${{matrix.db}}:${{matrix.version}} for test execution
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: dotnet ef migrations bundle --self-contained -r linux-x64 --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator/efbundle
-      - name: Execute Bundler ${{matrix.db}}:${{matrix.version}}
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: ./migrator/efbundle
-      - name: "Publish Artifact - migrator"
+        run: ./migrator-${{matrix.rid}}/efbundle
+      - name: "Publish Artifact - migrator-${{matrix.rid}}"
         uses: actions/upload-artifact@v3
         with:
-          name: migrator-${{matrix.os}}
-          path: "./migrator"
+          name: migrator-${{matrix.rid}}
+          path: "./migrator-${{matrix.rid}}"
       - name: Dotnet Cake Test ${{matrix.db}}:${{matrix.version}}
         run: dotnet cake --target=Test
         shell: pwsh
@@ -191,7 +191,7 @@ jobs:
       - name: "Download Artifact - migrator"
         uses: actions/download-artifact@v3
         with:
-          name: migrator-${{matrix.os}}
+          name: migrator-linux-x64
       - name: "List all files"
         run: ls -R
       - name: Execute efBundle ${{matrix.db}}:${{matrix.version}}
@@ -232,7 +232,7 @@ jobs:
       - name: Download Artifact - Migrator
         uses: actions/download-artifact@v3
         with:
-          name: migrator-${{matrix.os}}
+          name: migrator-linux-musl-x64 # We're targeting alpine so we require this binary RID
           path: "./migrator"
       - name: "Install QEMU"
         id: qemu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
         db: [mysql] # we require a MySQL Instance to build the efbundler
         version: ["8.0.27"]
         os: [ubuntu-latest] # windows-latest, macOS-latest'
-        rid: [linux-x64, linux-musl-x64]
     steps:
       - name: Pull ${{matrix.db}}:${{matrix.version}} and setup Docker
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -80,18 +79,31 @@ jobs:
       - name: "Dotnet Cake Build"
         run: dotnet cake --target=Build
         shell: pwsh
-      - name: Make ./migrator-${{matrix.rid}} directory
-        run: mkdir -p ./migrator-${{matrix.rid}}
-      - name: Build Bundler for ${{matrix.rid}} on ${{matrix.db}}:${{matrix.version}}
-        run: dotnet ef migrations bundle --self-contained -r ${{matrix.rid}} --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator-${{matrix.rid}}/efbundle
-      - name: Execute Bundler ${{matrix.db}}:${{matrix.version}} for test execution
+        
+      - name: Make ./migrator-linux-x64 directory
+        run: mkdir -p ./migrator-linux-x64
+      - name: Build Bundler for linux-x64 on ${{matrix.db}}:${{matrix.version}}
+        run: dotnet ef migrations bundle --self-contained -r linux-x64 --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator-linux-x64/efbundle
+      
+      - name: Execute migrator-linux-x64 ${{matrix.db}}:${{matrix.version}} for test execution
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: ./migrator-${{matrix.rid}}/efbundle
-      - name: "Publish Artifact - migrator-${{matrix.rid}}"
+        run: ./migrator-linux-x64/efbundle
+      - name: "Publish Artifact - migrator-linux-x64"
         uses: actions/upload-artifact@v3
         with:
-          name: migrator-${{matrix.rid}}
-          path: "./migrator-${{matrix.rid}}"
+          name: migrator-linux-x64
+          path: "./migrator-linux-x64"
+          
+      - name: Make ./migrator-linux-musl-x64 directory
+        run: mkdir -p ./migrator-linux-musl-x64
+      - name: Build Bundler for linux-musl-x64 on ${{matrix.db}}:${{matrix.version}}
+        run: dotnet ef migrations bundle --self-contained -r linux-musl-x64 --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator-linux-musl-x64/efbundle
+      - name: "Publish Artifact - migrator-linux-musl-x64"
+        uses: actions/upload-artifact@v3
+        with:
+          name: migrator-linux-musl-x64
+          path: "./migrator-linux-musl-x64"
+  
       - name: Dotnet Cake Test ${{matrix.db}}:${{matrix.version}}
         run: dotnet cake --target=Test
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         run: mkdir -p ./migrator
       - name: Build Bundler ${{matrix.db}}:${{matrix.version}}
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: dotnet ef migrations bundle --self-contained --verbose --configuration Release --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator/efbundle
+        run: dotnet ef migrations bundle --self-contained -r linux-x64 --verbose --configuration Bundle --project ./Source/WebScheduler.DataMigrations/WebScheduler.DataMigrations.csproj -o ./migrator/efbundle
       - name: Execute Bundler ${{matrix.db}}:${{matrix.version}}
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./migrator/efbundle

--- a/Source/WebScheduler.DataMigrations/Dockerfile
+++ b/Source/WebScheduler.DataMigrations/Dockerfile
@@ -31,5 +31,5 @@ RUN apk add --no-cache tree && tree /app
 FROM base AS runtime
 WORKDIR /app
 COPY --from=base /app .
-
-ENTRYPOINT ["efbundle"]
+RUN chmod +x /app/efbundle
+ENTRYPOINT ["/app/efbundle"]

--- a/Source/WebScheduler.DataMigrations/Dockerfile
+++ b/Source/WebScheduler.DataMigrations/Dockerfile
@@ -31,5 +31,5 @@ RUN apk add --no-cache tree && tree /app
 FROM base AS runtime
 WORKDIR /app
 COPY --from=base /app .
-RUN chmod +x /app/efbundle
-ENTRYPOINT ["/app/efbundle"]
+RUN chmod +x efbundle
+ENTRYPOINT ["efbundle"]


### PR DESCRIPTION
Updates the image names in app spec from work in #159.

This fixes an issue where efbundle needed to target RID linux-musl-x64 when running on alpine.

We now build a linux-musl-x64 and a linux-x64 to run within the CI for test runners on ubuntu.