### PR TITLE
Don't manually deactivate ScheduledTaskHistoryGrain

### DIFF
--- a/Source/WebScheduler.Grains/Scheduler/ScheduledTaskHistoryGrain.cs
+++ b/Source/WebScheduler.Grains/Scheduler/ScheduledTaskHistoryGrain.cs
@@ -33,7 +33,7 @@ public class ScheduledTaskHistoryGrain : Grain, IHistoryGrain<ScheduledTaskMetad
         {
             this.historyRecordState.State = history;
             await this.historyRecordState.WriteStateAsync().ConfigureAwait(true);
-            this.DeactivateOnIdle();
+
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/web-scheduler/web-scheduler/blob/main/.github/CONTRIBUTING.md
-->

This change resolved #168 by removing the call to  `this.DeactivateOnIdle()`.