### PR TITLE
Bump dockerfile base image to use "latest" 6.0

### DIFF
--- a/Source/WebScheduler.Server/Dockerfile
+++ b/Source/WebScheduler.Server/Dockerfile
@@ -5,7 +5,7 @@
 
 # Base image used by Visual Studio at development time
 # (See https://docs.microsoft.com/en-us/visualstudio/containers/container-msbuild-properties)
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.5-alpine3.15-amd64 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
 # Open Container Initiative (OCI) labels (See https://github.com/opencontainers/image-spec/blob/master/annotations.md).
 LABEL org.opencontainers.image.title="Web Scheduler" \
     org.opencontainers.image.description="A general web scheduler with a variety of triggers." \
@@ -28,7 +28,7 @@ WORKDIR /app
 EXPOSE 80 11111 30000
 
 # SDK image used to build and publish the application
-FROM mcr.microsoft.com/dotnet/sdk:6.0.300-alpine3.15-amd64 AS sdk
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS sdk
 
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true


### PR DESCRIPTION
<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/web-scheduler/web-scheduler/blob/main/.github/CONTRIBUTING.md
-->
