### PR TITLE
Remove concurrent state mutation to simplify the history process and add Exception Observer support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,10 @@ jobs:
         version: ["8.0.27"]
         os: [ubuntu-latest] # windows-latest, macOS-latest'
     steps:
+      - name: Sets env vars for release
+        run: |
+          echo "MINVERBUILDMETADATA: build.${{github.run_number}}" >> $GITHUB_ENV
+        if: github.event_name != 'release'
       - name: Pull ${{matrix.db}}:${{matrix.version}} and setup Docker
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
         version: ["8.0.27"]
         os: [ubuntu-latest] # windows-latest, macOS-latest'
     steps:
-      - name: Sets env vars for release
+      - name: Sets MINVERBUILDMETADATA to build.${{github.run_number}}
         run: |
-          echo "MINVERBUILDMETADATA: build.${{github.run_number}}" >> $GITHUB_ENV
+          echo "MINVERBUILDMETADATA=build.${{github.run_number}}" >> $GITHUB_ENV
         if: github.event_name != 'release'
       - name: Pull ${{matrix.db}}:${{matrix.version}} and setup Docker
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/Source/WebScheduler.Abstractions/Services/IExceptionObserver.cs
+++ b/Source/WebScheduler.Abstractions/Services/IExceptionObserver.cs
@@ -1,0 +1,27 @@
+namespace WebScheduler.Abstractions.Services;
+using System;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Allows for consumers of the WebScheduler packages to observe internal exceptions and context of the exception.
+/// </summary>
+public interface IExceptionObserver
+{
+    /// <summary>
+    /// Called when an exception occurs with a grain.
+    /// </summary>
+    /// <param name="exception">The exception.</param>
+    ValueTask OnException(Exception exception);
+}
+
+/// <summary>
+/// An example ExceptionObserver that does nothing.
+/// </summary>
+public class NoOpExceptionObserver : IExceptionObserver
+{
+    /// <summary>
+    /// Called when an exception occurs with a grain.
+    /// </summary>
+    /// <param name="exception"></param>
+    public ValueTask OnException(Exception exception) => ValueTask.CompletedTask;
+}

--- a/Source/WebScheduler.Abstractions/Services/IExceptionObserverExtensions.cs
+++ b/Source/WebScheduler.Abstractions/Services/IExceptionObserverExtensions.cs
@@ -1,0 +1,27 @@
+namespace WebScheduler.Abstractions.Services;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Extension methods for <see cref="IExceptionObserver"/>
+/// </summary>
+public static class IExceptionObserverExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ValueTask ObserveException(this IExceptionObserver? exceptionObserver, Exception exception)
+    {
+        if (exceptionObserver is null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        var valueTask = exceptionObserver.OnException(exception);
+        if (valueTask.IsCompleted)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return valueTask;
+    }
+}

--- a/Source/WebScheduler.Grains/History/HistoryGrain.cs
+++ b/Source/WebScheduler.Grains/History/HistoryGrain.cs
@@ -1,5 +1,6 @@
 namespace WebScheduler.Grains.History;
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
@@ -8,6 +9,7 @@ using Orleans.Placement;
 using Orleans.Runtime;
 using WebScheduler.Abstractions.Grains.History;
 using WebScheduler.Abstractions.Grains.Scheduler;
+using WebScheduler.Abstractions.Services;
 
 /// <summary>
 /// Base class for recording history
@@ -19,16 +21,19 @@ public abstract class HistoryGrain<TModel, TOperationType> : Grain, IHistoryGrai
     where TModel : class, IHistoryRecordKeyPrefix, new()
     where TOperationType : Enum
 {
+    private readonly IExceptionObserver? exceptionObserver;
     private readonly ILogger logger;
     private readonly IPersistentState<HistoryState<TModel, TOperationType>> historyRecordState;
     private static readonly TimeSpan OneMinute = TimeSpan.FromMinutes(1);
     /// <summary>
     /// ctor
     /// </summary>
+    /// <param name="exceptionObserver"></param>
     /// <param name="logger"></param>
     /// <param name="state"></param>
-    protected HistoryGrain(ILogger logger, IPersistentState<HistoryState<TModel, TOperationType>> state)
+    protected HistoryGrain(IExceptionObserver exceptionObserver, ILogger logger, IPersistentState<HistoryState<TModel, TOperationType>> state)
     {
+        this.exceptionObserver = exceptionObserver;
         this.logger = logger;
         this.historyRecordState = state;
     }
@@ -74,6 +79,9 @@ public abstract class HistoryGrain<TModel, TOperationType> : Grain, IHistoryGrai
             // Reset the state in event of failure
             this.historyRecordState.State = default!;
             this.logger.ErrorRecordingHistory(ex, this.GetPrimaryKeyString());
+
+            await this.exceptionObserver!.OnException(ex);
+
             return false;
         }
     }

--- a/Source/WebScheduler.Grains/Scheduler/ScheduledTaskHistoryGrain.cs
+++ b/Source/WebScheduler.Grains/Scheduler/ScheduledTaskHistoryGrain.cs
@@ -7,6 +7,7 @@ using WebScheduler.Abstractions.Grains.Scheduler;
 using WebScheduler.Grains.Constants;
 using Orleans.Placement;
 using WebScheduler.Grains.History;
+using WebScheduler.Abstractions.Services;
 
 /// <summary>
 /// History for <see cref="IScheduledTaskGrain"/>.
@@ -18,10 +19,12 @@ public class ScheduledTaskHistoryGrain : HistoryGrain<ScheduledTaskMetadata, Sch
     /// The ctor.
     /// </summary>
     /// <param name="logger">logger</param>
+    /// <param name="exceptionObserver"></param>
     /// <param name="state">state</param>
     public ScheduledTaskHistoryGrain(
         ILogger<ScheduledTaskHistoryGrain> logger,
+        IExceptionObserver exceptionObserver,
         [PersistentState(StateName.ScheduledTaskMetadataHistory, GrainStorageProviderName.ScheduledTaskMetadataHistory)]
-        IPersistentState<HistoryState<ScheduledTaskMetadata,ScheduledTaskOperationType>> state) : base(logger, state)
+        IPersistentState<HistoryState<ScheduledTaskMetadata,ScheduledTaskOperationType>> state) : base(exceptionObserver, logger, state)
     { }
 }

--- a/Source/WebScheduler.Grains/Scheduler/ScheduledTaskTriggerHistoryGrain.cs
+++ b/Source/WebScheduler.Grains/Scheduler/ScheduledTaskTriggerHistoryGrain.cs
@@ -7,6 +7,7 @@ using WebScheduler.Abstractions.Grains.Scheduler;
 using WebScheduler.Grains.Constants;
 using Orleans.Placement;
 using WebScheduler.Grains.History;
+using WebScheduler.Abstractions.Services;
 
 /// <summary>
 /// Records <see cref="ScheduledTaskTriggerHistoryGrain"/> history.
@@ -17,11 +18,13 @@ public class ScheduledTaskTriggerHistoryGrain : HistoryGrain<ScheduledTaskTrigge
     /// <summary>
     /// The ctor.
     /// </summary>
+    /// <param name="exceptionObserver"></param>
     /// <param name="logger">logger</param>
     /// <param name="state">state</param>
     public ScheduledTaskTriggerHistoryGrain(
+        IExceptionObserver exceptionObserver,
         ILogger<ScheduledTaskTriggerHistoryGrain> logger,
         [PersistentState(StateName.ScheduledTaskTriggerHistory, GrainStorageProviderName.ScheduledTaskTriggerHistory)]
-        IPersistentState<HistoryState<ScheduledTaskTriggerHistory, TaskTriggerType>> state) : base(logger, state)
+        IPersistentState<HistoryState<ScheduledTaskTriggerHistory, TaskTriggerType>> state) : base(exceptionObserver, logger, state)
     { }
 }

--- a/Source/WebScheduler.Server/Startup.cs
+++ b/Source/WebScheduler.Server/Startup.cs
@@ -35,7 +35,8 @@ public class Startup
             .AddCheck<GrainHealthCheck>(nameof(GrainHealthCheck))
             .AddCheck<SiloHealthCheck>(nameof(SiloHealthCheck))
             .AddCheck<StorageHealthCheck>(nameof(StorageHealthCheck)).Services
-            .AddSingleton<IClockService, ClockService>();
+            .AddSingleton<IClockService, ClockService>()
+            .AddSingleton<IExceptionObserver, NoOpExceptionObserver>();
 
     public virtual void Configure(IApplicationBuilder application) =>
         application

--- a/Tests/WebScheduler.Abstractions.Tests/ExceptionObserverTests.cs
+++ b/Tests/WebScheduler.Abstractions.Tests/ExceptionObserverTests.cs
@@ -1,0 +1,43 @@
+namespace WebScheduler.Abstractions.Tests;
+using System;
+using System.Threading.Tasks;
+using FakeItEasy;
+using FluentAssertions;
+using WebScheduler.Abstractions.Services;
+using Xunit;
+
+public class ExceptionObserverTests
+{
+    [Theory]
+    [MemberData(nameof(AggregateExceptionTestData))]
+    public async void IExceptionObserverExtensions_Works<T>(T exception)
+        where T : Exception
+    {
+        var fakeExceptionObserver = A.Fake<IExceptionObserver>();
+
+        Type typePassed = null!;
+        A.CallTo(() => fakeExceptionObserver.OnException(A<T>.That.IsInstanceOf(typeof(T)))).ReturnsLazily(c =>
+        {
+            typePassed = c.Arguments[0].GetType();
+            return ValueTask.CompletedTask;
+        });
+
+        await fakeExceptionObserver.ObserveException(exception);
+        typePassed.Should().Be<T>();
+    }
+
+    public static IEnumerable<object[]> AggregateExceptionTestData()
+    {
+        var types = new Exception[]
+        {
+                new AggregateException(),
+                new ArgumentNullException(),
+                new InvalidOperationException()
+        };
+
+        foreach (var type in types)
+        {
+            yield return new[] { type };
+        }
+    }
+}

--- a/Tests/WebScheduler.Abstractions.Tests/WebScheduler.Abstractions.Tests.csproj
+++ b/Tests/WebScheduler.Abstractions.Tests/WebScheduler.Abstractions.Tests.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/WebScheduler.Abstractions.Tests/xunit.runner.json
+++ b/Tests/WebScheduler.Abstractions.Tests/xunit.runner.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+  {
+    "appDomain": "ifAvailable",
+    "diagnosticMessages": true,
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false,
+    "methodDisplay": "classAndMethod",
+    "shadowCopy": false
+  }
+}

--- a/Tests/WebScheduler.Server.IntegrationTest/xunit.runner.json
+++ b/Tests/WebScheduler.Server.IntegrationTest/xunit.runner.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+  {
+    "appDomain": "ifAvailable",
+    "diagnosticMessages": true,
+    "parallelizeAssembly": false,
+    "parallelizeTestCollections": false,
+    "methodDisplay": "classAndMethod",
+    "shadowCopy": false
+  }
+}

--- a/WebScheduler.sln
+++ b/WebScheduler.sln
@@ -24,7 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		dotnet-tools.json = dotnet-tools.json
-		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
 	EndProjectSection
 EndProject
@@ -67,6 +66,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".do", ".do", "{95B06FEA-F58
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebScheduler.DataMigrations", "Source\WebScheduler.DataMigrations\WebScheduler.DataMigrations.csproj", "{833FDF75-238A-43ED-A68B-31BEE2788F31}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebScheduler.Abstractions.Tests", "Tests\WebScheduler.Abstractions.Tests\WebScheduler.Abstractions.Tests.csproj", "{48010DB7-189C-429E-A4B6-E95D07BB7028}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +94,10 @@ Global
 		{833FDF75-238A-43ED-A68B-31BEE2788F31}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{833FDF75-238A-43ED-A68B-31BEE2788F31}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{833FDF75-238A-43ED-A68B-31BEE2788F31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48010DB7-189C-429E-A4B6-E95D07BB7028}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48010DB7-189C-429E-A4B6-E95D07BB7028}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48010DB7-189C-429E-A4B6-E95D07BB7028}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48010DB7-189C-429E-A4B6-E95D07BB7028}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -107,6 +112,7 @@ Global
 		{90F1A60D-6607-44BF-AB4C-F53B1E31194F} = {60E0F62E-605A-48F2-BFCA-C63B45AB6335}
 		{90110DBA-335A-4A7A-AD43-48CB1A15346D} = {90F1A60D-6607-44BF-AB4C-F53B1E31194F}
 		{833FDF75-238A-43ED-A68B-31BEE2788F31} = {57BAE1BC-D418-4A95-B292-C0E9324B0A54}
+		{48010DB7-189C-429E-A4B6-E95D07BB7028} = {D57B72FA-A893-400C-AB2E-6919219A38D2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4E464B40-8B3D-427D-BA61-053DB0B94967}


### PR DESCRIPTION
Fixes #242.

Implements `IExceptionObserver` to allow passing exceptions to observers outside of the grains.

Removes write concurrency around writing task history.