### PR TITLE
Add index to OrleansStorage for GrainIdHash_GrainTypeHash

### DIFF
--- a/Source/WebScheduler.DataMigrations/Migrations/20220902235510_Add IX_GrainIdHash_GrainTypeHash to OrleansStorage table.Designer.cs
+++ b/Source/WebScheduler.DataMigrations/Migrations/20220902235510_Add IX_GrainIdHash_GrainTypeHash to OrleansStorage table.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using WebScheduler.DataMigrations;
 
@@ -11,9 +12,10 @@ using WebScheduler.DataMigrations;
 namespace WebScheduler.DataMigrations.Migrations
 {
     [DbContext(typeof(OrleansDbContext))]
-    partial class OrleansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220902235510_Add IX_OrleansStorage to OrleansStorage table")]
+    partial class AddIX_OrleansStoragetoOrleansStoragetable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/WebScheduler.DataMigrations/Migrations/20220902235510_Add IX_GrainIdHash_GrainTypeHash to OrleansStorage table.cs
+++ b/Source/WebScheduler.DataMigrations/Migrations/20220902235510_Add IX_GrainIdHash_GrainTypeHash to OrleansStorage table.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebScheduler.DataMigrations.Migrations
+{
+    public partial class AddIX_OrleansStoragetoOrleansStoragetable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.CreateIndex(
+                name: "IX_OrleansStorage",
+                table: "OrleansStorage",
+                columns: new[] { "GrainIdHash", "GrainTypeHash" });
+
+        protected override void Down(MigrationBuilder migrationBuilder) => migrationBuilder.DropIndex(
+                name: "IX_OrleansStorage",
+                table: "OrleansStorage");
+    }
+}

--- a/Source/WebScheduler.DataMigrations/Migrations/20220902235510_Add IX_GrainIdHash_GrainTypeHash to OrleansStorage table.cs
+++ b/Source/WebScheduler.DataMigrations/Migrations/20220902235510_Add IX_GrainIdHash_GrainTypeHash to OrleansStorage table.cs
@@ -6,13 +6,27 @@ namespace WebScheduler.DataMigrations.Migrations
 {
     public partial class AddIX_OrleansStoragetoOrleansStoragetable : Migration
     {
-        protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.CreateIndex(
-                name: "IX_OrleansStorage",
-                table: "OrleansStorage",
-                columns: new[] { "GrainIdHash", "GrainTypeHash" });
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("/*!80013 SET SQL_REQUIRE_PRIMARY_KEY = 0 */;");
 
-        protected override void Down(MigrationBuilder migrationBuilder) => migrationBuilder.DropIndex(
+            migrationBuilder.Sql("ALTER TABLE `OrleansStorage` DROP PRIMARY KEY, ADD PRIMARY KEY(Id);");
+
+            migrationBuilder.Sql("/*!80013 SET SQL_REQUIRE_PRIMARY_KEY = 1 */;");
+            migrationBuilder.Sql("ALTER TABLE `OrleansStorage` ADD INDEX IX_OrleansStorage (GrainIdHash, GrainTypeHash);");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("/*!80013 SET SQL_REQUIRE_PRIMARY_KEY = 0 */;");
+
+            migrationBuilder.DropIndex(
                 name: "IX_OrleansStorage",
                 table: "OrleansStorage");
+
+            migrationBuilder.DropPrimaryKey("PRIMARY", "OrleansStorage");
+            migrationBuilder.Sql("ALTER TABLE `OrleansStorage` ADD PRIMARY KEY(Id, GrainIdHash, GrainTypeHash);");
+            migrationBuilder.Sql("/*!80013 SET SQL_REQUIRE_PRIMARY_KEY = 1 */;");
+        }
     }
 }

--- a/Source/WebScheduler.DataMigrations/OrleansDbContext.cs
+++ b/Source/WebScheduler.DataMigrations/OrleansDbContext.cs
@@ -114,6 +114,9 @@ public class OrleansDbContext : DbContext
                 entity.HasKey(e => new { e.Id, e.GrainIdHash, e.GrainTypeHash })
                 .HasName("PRIMARY");
 
+                entity.HasIndex(e => new { e.GrainIdHash, e.GrainTypeHash })
+                .HasDatabaseName("IX_OrleansStorage");
+
                 entity.ToTable("OrleansStorage");
 
                 entity.Property(e => e.GrainIdExtensionString)


### PR DESCRIPTION
Re-adds index previously dropped and never readded in #159.

Results in table schema:

```sql
CREATE TABLE
  `OrleansStorage` (
    `GrainIdHash` int NOT NULL,
    `GrainIdN0` bigint NOT NULL,
    `GrainIdN1` bigint NOT NULL,
    `GrainTypeHash` int NOT NULL,
    `GrainTypeString` varchar(512) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
    `GrainIdExtensionString` varchar(512) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL,
    `ServiceId` varchar(150) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
    `PayloadBinary` blob,
    `PayloadXml` longtext,
    `PayloadJson` json DEFAULT NULL,
    `ModifiedOn` datetime NOT NULL,
    `Version` int DEFAULT NULL,
    `Id` bigint NOT NULL AUTO_INCREMENT,
    PRIMARY KEY (`Id`),
    KEY `IX_OrleansStorage` (`GrainIdHash`, `GrainTypeHash`)
  ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 16
```

 