### PR TITLE
Switch `IHttpClientFactory` to allow for custom HttpClientFactories

### DIFF
--- a/Source/WebScheduler.Abstractions/Options/ScheduledTaskGrainOptions.cs
+++ b/Source/WebScheduler.Abstractions/Options/ScheduledTaskGrainOptions.cs
@@ -1,5 +1,14 @@
 namespace WebScheduler.Abstractions.Options;
+
+using WebScheduler.Abstractions.Grains.Scheduler;
+
+/// <summary>
+/// Options to configure <see cref="IScheduledTaskGrain"/>
+/// </summary>
 public class ScheduledTaskGrainOptions
 {
-    public Func<HttpClient> ClientFactory = () => new HttpClient();
+    /// <summary>
+    /// The factory for creating <see cref="HttpClient"/>.
+    /// </summary>
+    public Func<HttpClient> ClientFactory { get; set; } = () => new HttpClient();
 }

--- a/Source/WebScheduler.Abstractions/Options/ScheduledTaskGrainOptions.cs
+++ b/Source/WebScheduler.Abstractions/Options/ScheduledTaskGrainOptions.cs
@@ -1,0 +1,5 @@
+namespace WebScheduler.Abstractions.Options;
+public class ScheduledTaskGrainOptions
+{
+    public Func<HttpClient> ClientFactory = () => new HttpClient();
+}

--- a/Source/WebScheduler.Grains/Scheduler/ScheduledTaskGrain.cs
+++ b/Source/WebScheduler.Grains/Scheduler/ScheduledTaskGrain.cs
@@ -30,6 +30,7 @@ public class ScheduledTaskGrain : Grain, IScheduledTaskGrain, IRemindable, ITena
     private readonly IHttpClientFactory httpClientFactory;
     private readonly IClusterClient clusterClient;
     private const string ScheduledTaskReminderName = "ScheduledTaskExecutor";
+    private const string ScheduledTaskHttpClientName = "ScheduledTaskHttpClient";
     private CronExpression? expression;
     private readonly Stopwatch stopwatch = new();
     private IGrainReminder? scheduledTaskReminder;
@@ -547,7 +548,7 @@ public class ScheduledTaskGrain : Grain, IScheduledTaskGrain, IRemindable, ITena
             Operation = TaskTriggerType.HttpTrigger,
         };
 
-        var client = this.httpClientFactory.CreateClient();
+        var client = this.httpClientFactory.CreateClient(ScheduledTaskHttpClientName);
 
         StringContent? content = null;
 

--- a/Source/WebScheduler.Server/Startup.cs
+++ b/Source/WebScheduler.Server/Startup.cs
@@ -5,9 +5,12 @@ using WebScheduler.ConfigureOptions;
 using WebScheduler.Server.HealthChecks;
 using Serilog;
 using WebScheduler.Abstractions.Services;
+using WebScheduler.Abstractions.Options;
+
 public class Startup
 #pragma warning restore CA1724 // The type name conflicts with the namespace name 'Orleans.Runtime.Startup'
 {
+    private const string ScheduledTaskHttpClientName = "ScheduledTaskHttpClient";
     private readonly IConfiguration configuration;
     private readonly IWebHostEnvironment webHostEnvironment;
 
@@ -29,7 +32,8 @@ public class Startup
             .ConfigureOptions<ConfigureRequestLoggingOptions>()
             .AddRouting(options => options.LowercaseUrls = true)
             .AddCustomOpenTelemetryTracing(this.webHostEnvironment)
-            .AddHttpClient("ScheduledTaskHttpClient").Services
+            .AddHttpClient(ScheduledTaskHttpClientName).Services
+            .AddOptions<ScheduledTaskGrainOptions>().Configure<IServiceProvider>((c, s) => c.ClientFactory = () => s.GetRequiredService<IHttpClientFactory>().CreateClient(ScheduledTaskHttpClientName)).Services
             .AddHealthChecks()
             .AddCheck<ClusterHealthCheck>(nameof(ClusterHealthCheck))
             .AddCheck<GrainHealthCheck>(nameof(GrainHealthCheck))

--- a/Source/WebScheduler.Server/Startup.cs
+++ b/Source/WebScheduler.Server/Startup.cs
@@ -29,7 +29,7 @@ public class Startup
             .ConfigureOptions<ConfigureRequestLoggingOptions>()
             .AddRouting(options => options.LowercaseUrls = true)
             .AddCustomOpenTelemetryTracing(this.webHostEnvironment)
-            .AddHttpClient()
+            .AddHttpClient("ScheduledTaskHttpClient").Services
             .AddHealthChecks()
             .AddCheck<ClusterHealthCheck>(nameof(ClusterHealthCheck))
             .AddCheck<GrainHealthCheck>(nameof(GrainHealthCheck))


### PR DESCRIPTION
This PR allows for controlling the `HttpClient` factor used to match the use-case needs. By default it will make a new `HttpClient` for each task.

It is recommended to use `IHttpClientFactory` or if you need more control to use `SocketsHttpHandler`.