### PR TITLE
Resolve deprecation of MinVerDefaultPreReleasePhase for MinVer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Versioning">
-    <MinVerDefaultPreReleasePhase>alpha</MinVerDefaultPreReleasePhase>
+    <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
     <MinVerVerbosity>normal</MinVerVerbosity>
   </PropertyGroup>
 

--- a/build.cake
+++ b/build.cake
@@ -192,7 +192,7 @@ string GetVersion()
 {
     var directoryBuildPropsFilePath = GetFiles("Directory.Build.props").Single().ToString();
     var directoryBuildPropsDocument = System.Xml.Linq.XDocument.Load(directoryBuildPropsFilePath);
-    var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleasePhase").Single().Value;
+    var preReleasePhase = directoryBuildPropsDocument.Descendants("MinVerDefaultPreReleaseIdentifiers").Single().Value;
 
     var exitCode = StartProcess(
         "dotnet",


### PR DESCRIPTION
MinVer is deprecating MinVerDefaultPreReleasePhase in favor of MinVerDefaultPreReleaseIdentifiers

See https://github.com/adamralph/minver/pull/839