### PR TITLE
Revert "Bump Microsoft.Orleans.* from 3.6.5 to 3.7.0"

### DIFF
--- a/Source/WebScheduler.Abstractions/WebScheduler.Abstractions.csproj
+++ b/Source/WebScheduler.Abstractions/WebScheduler.Abstractions.csproj
@@ -40,10 +40,10 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Version="1.1.1" Condition="'$(GitHub)' == 'true'" />
 
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.7.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.6.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.7.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.6.5" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/WebScheduler.Grains/WebScheduler.Grains.csproj
+++ b/Source/WebScheduler.Grains/WebScheduler.Grains.csproj
@@ -33,12 +33,12 @@
     <PackageReference Include="Cronos" Version="0.7.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.7.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.6.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="3.7.0" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.Runtime.Abstractions" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="3.6.5" />
     <PackageReference Include="Orleans.StorageProviderInterceptors" Version="0.0.6" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/Source/WebScheduler.Server/WebScheduler.Server.csproj
+++ b/Source/WebScheduler.Server/WebScheduler.Server.csproj
@@ -32,23 +32,23 @@
     <PackageReference Include="Boxed.AspNetCore" Version="8.1.2+build.669" />
     <PackageReference Include="Cronos" Version="0.7.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="3.7.0" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="3.6.5" />
     <PackageReference Include="MySqlConnector" Version="2.2.5" />
     <PackageReference Include="Orleans.StorageProviderInterceptors" Version="0.0.6" />
     <PackageReference Include="OrleansDashboard" Version="3.6.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.7.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" PrivateAssets="all" Version="3.6.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Linux" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="3.7.0" />
-    <PackageReference Include="Microsoft.Orleans.Transactions" Version="3.7.0" />
+    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Linux" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="3.6.5" />
+    <PackageReference Include="Microsoft.Orleans.Transactions" Version="3.6.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />

--- a/Tests/WebScheduler.Abstractions.Tests/WebScheduler.Abstractions.Tests.csproj
+++ b/Tests/WebScheduler.Abstractions.Tests/WebScheduler.Abstractions.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="4.2.0" />
     <PackageReference Include="FluentAssertions.Web" Version="1.2.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.7.0" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.6.5" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />

--- a/Tests/WebScheduler.Server.IntegrationTest/WebScheduler.Server.IntegrationTest.csproj
+++ b/Tests/WebScheduler.Server.IntegrationTest/WebScheduler.Server.IntegrationTest.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="4.2.0" />
     <PackageReference Include="FluentAssertions.Web" Version="1.2.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.7.0" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="3.6.5" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />


### PR DESCRIPTION
Reverts web-scheduler/web-scheduler#416

Reverting because this requires a DB migration.